### PR TITLE
fix destruction of damage texts

### DIFF
--- a/SomniatProject/Assets/Scripts/Player/DamageTextPlayer.cs
+++ b/SomniatProject/Assets/Scripts/Player/DamageTextPlayer.cs
@@ -41,7 +41,7 @@ public class DamgeTextPlayer : ScriptableObject
             await Task.Delay(10);
         }
 
-        Destroy(damageText);
+        Destroy(damageText.gameObject);
     }
 
     private Color AddHealthColor(int value)


### PR DESCRIPTION
Current code only deletes teh TextMeshPro component of the damage texts that pop up and not the whole obj. Fix deletes the obj.